### PR TITLE
catch empty PageToPdf output

### DIFF
--- a/ocrd-pagetopdf
+++ b/ocrd-pagetopdf
@@ -147,7 +147,10 @@ main () {
  
         info "found image file '$img_file'"
         if ! output=$(java -jar "$SHAREDIR/ptp/PageToPdf.jar" "${options[@]}" 2>&1); then
-            error "PdfToPdf failed for ID $in_id (pageId=$pageid): $output"
+            error "PageToPdf failed for ID $in_id (pageId=$pageid): $output"
+            continue
+        elif ! [ -f "$out_file" ]; then
+            error "PageToPdf result is empty for ID $in_id (pageId=$pageid): $output"
             continue
         fi
         


### PR DESCRIPTION
It is not enough to check the error status of PageToPdf. (IIUC it _never_ exits with non-zero status.)

This also fixes the failure in `multipage` mode when _not_ catching the error. (It would not find the file in the postscript, and output the following... 
```
Error: /undefinedfilename in (OCR-D-PDF-OCR-TESS-deu-SEG-ocropus/OCR-D-PDF-OCR-TESS-deu-SEG-ocropus_GutachtenLW15-1.pdf)
Operand stack:

Execution stack:
   %interp_exit   .runexec2   --nostringval--   --nostringval--   --nostringval--   2   %stopped_push   --nostringval--   --nostringval--   --nostringval--   false   1   %stopped_push
Dictionary stack:
   --dict:958/1684(ro)(G)--   --dict:1/20(G)--   --dict:77/200(L)--
Current allocation mode is local
Last OS error: No such file or directory
GPL Ghostscript 9.26: Unrecoverable error, exit code 1
```

BTW, I think what _really_ should be done here with bad pages (besides the error messag) is using ImageMagick to convert the original image to a PDF without any annotations. The only extra requirement would be `imagemagick` (as in ocrd_im6convert).