### PR TITLE
Makefile: Add deps-ubuntu target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help:
 
 # Install system packages (on Debian/Ubuntu)
 deps-ubuntu:
-	apt-get install -y make python3 python3-pip python3-venv openjdk-8-jre-headless ghostscript
+	apt-get install -y python3 python3-venv openjdk-8-jre-headless ghostscript
 
 # Install python packages
 deps:

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ help:
 
 # Install system packages (on Debian/Ubuntu)
 deps-ubuntu:
-	apt-get install -y make python3 python3-pip python3-venv openjdk-8-jdk
+	apt-get install -y make python3 python3-pip python3-venv openjdk-8-jre-headless ghostscript
 
 # Install python packages
 deps:

--- a/Makefile
+++ b/Makefile
@@ -16,16 +16,21 @@ help:
 	@echo ""
 	@echo "  Targets"
 	@echo ""
-	@echo "    deps       Install python packages"
-	@echo "    install    Install the executable in $(PREFIX)/bin and the ocrd-tool.json to $(SHAREDIR)"
-	@echo "    uninstall  Uninstall scripts and $(SHAREDIR)"
-	@echo "    docker     Build Docker image"
+	@echo "    deps-ubuntu	Install system packages (on Debian/Ubuntu)"
+	@echo "    deps       	Install python packages"
+	@echo "    install    	Install the executable in $(PREFIX)/bin and the ocrd-tool.json to $(SHAREDIR)"
+	@echo "    uninstall  	Uninstall scripts and $(SHAREDIR)"
+	@echo "    docker     	Build Docker image"
 	@echo ""
 	@echo "  Variables"
 	@echo ""
 	@echo "    PREFIX  Directory to install to ('$(PREFIX)')"
 
 # END-EVAL
+
+# Install system packages (on Debian/Ubuntu)
+deps-ubuntu:
+	apt-get install -y make python3 python3-pip python3-venv openjdk-8-jdk
 
 # Install python packages
 deps:


### PR DESCRIPTION
Add target for installing the system dependencies listed in the README on a Debian/Ubuntu system.

Follows the same naming format of other ocrd modules (e.g. [core](https://github.com/OCR-D/core)), and could be used by [ocrd-all](https://github.com/OCR-D/ocrd_all) when installing this module (I had to install `openjdk` manually after installing this with ocrd-all).