### PR TITLE
params -> ocrd__argv for overwrite

### DIFF
--- a/ocrd-pagetopdf
+++ b/ocrd-pagetopdf
@@ -157,7 +157,7 @@ main () {
     done
     
     if [ ${params['multipage']:=} ]; then
-        python3 "$SHAREDIR/ptp/multipagepdf.py" "$mets" "$out_file_grp" "${params['multipage']}" "${params['pagelabel']}" "${params['overwrite']}"
+        python3 "$SHAREDIR/ptp/multipagepdf.py" "$mets" "$out_file_grp" "${params['multipage']}" "${params['pagelabel']}" "${ocrd__argv['overwrite']}"
     fi
 }
 


### PR DESCRIPTION
There was a typo in #15, `params` should have been `ocrd__argv` for the `overwrite` CLI arg to multipagepdf.py