### PR TITLE
various fixes

### DIFF
--- a/ocrd-pagetopdf
+++ b/ocrd-pagetopdf
@@ -158,7 +158,7 @@ main () {
     done
     
     if [ ${params['multipage']:=} ]; then
-        python3 "$SHAREDIR/ptp/multipagepdf.py" "$mets" "$out_file_grp" "${params['multipage']}" "${params['pagelabel']}" "${ocrd__argv['overwrite']}"
+        python3 "$SHAREDIR/ptp/multipagepdf.py" "$mets" "$out_file_grp" "$page_id" "${params['multipage']}" "${params['pagelabel']}" "${ocrd__argv['overwrite']}"
     fi
 }
 

--- a/ocrd-pagetopdf
+++ b/ocrd-pagetopdf
@@ -103,6 +103,7 @@ main () {
         if [ -n "$img_file_grp" ]; then
             img_file=$(ocrd workspace find \
                             -g $pageid -G $img_file_grp \
+                            -m //image/.* \
                             -k local_filename --download)
         else
             # we could use xsltproc or xmlstarlet for this

--- a/ocrd-pagetopdf
+++ b/ocrd-pagetopdf
@@ -130,7 +130,7 @@ main () {
         if ! output=$(java -jar "$SHAREDIR/ptp/PageToPdf.jar" "${options[@]}" 2>&1); then
             ocrd log error "PageToPdf failed for ID $in_id (pageId=$pageid): $output"
             continue
-        elif ! [ -f "$out_file" ]; then
+        elif ! [ -f "$out_file" -a -s "$out_file" ]; then
             ocrd log error "PageToPdf result is empty for ID $in_id (pageId=$pageid): $output"
             continue
         fi

--- a/ocrd-pagetopdf
+++ b/ocrd-pagetopdf
@@ -103,7 +103,7 @@ main () {
         if [ -n "$img_file_grp" ]; then
             img_file=$(ocrd workspace find \
                             -g $pageid -G $img_file_grp \
-                            -m //image/.* \
+                            -m '//image/.*' \
                             -k local_filename --download)
         else
             # we could use xsltproc or xmlstarlet for this

--- a/ptp/multipagepdf.py
+++ b/ptp/multipagepdf.py
@@ -5,7 +5,7 @@ import sys
 import subprocess
 
 from ocrd_models import OcrdMets
-from ocrd_utils.logging import getLogger
+from ocrd_utils.logging import getLogger, initLogging
 from atomicwrites import atomic_write
 from ocrd_models.constants import NAMESPACES as NS
 
@@ -80,4 +80,5 @@ def pdfmerge(inputfiles, outputfile, pagelabels=None, metadata=None, store_tmp=F
         return 1
 
 if __name__=='__main__':
+    initLogging()
     read_from_mets(*sys.argv[1:])


### PR DESCRIPTION
Fixes #18.

Also fixes a yet undetected bug that relates to the new ([1-yr old](https://github.com/OCR-D/spec/commit/c385c9ccf93594ad17c03c3cceff89bcc2a8db61)) convention in OCR-D that derived images be placed into the output fileGrp as well.

There was also a bug that prevented `gs` errors from getting detected, and encapsulates its output into a debug-level logger (instead of direct stdout).

Plus it makes the merged PDF from the processed pages only (not all pages).

