### PR TITLE
Use first bash from PATH (allows running on macOS)

### DIFF
--- a/ocrd-pagetopdf
+++ b/ocrd-pagetopdf
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eu
 set -o pipefail
 # showing cmd execution on std (deactivated for productive use)


### PR DESCRIPTION
/bin/bash on macOS is too old (3.2.57), but can be replaced by a recent bash version from Homebrew.