### PR TITLE
Make ocrd-tool conform to schema

### DIFF
--- a/ocrd_pagetopdf/ocrd-tool.json
+++ b/ocrd_pagetopdf/ocrd-tool.json
@@ -10,7 +10,7 @@
         "Long-term preservation"
       ],
       "steps": [
-        "post-processing/format-conversion"
+        "postprocessing/format-conversion"
       ],
       "input_file_grp_cardinality": 1,
       "output_file_grp_cardinality": 1,
@@ -197,7 +197,7 @@
         "Long-term preservation"
       ],
       "steps": [
-        "post-processing/format-conversion"
+        "postprocessing/format-conversion"
       ],
       "input_file_grp_cardinality": 2,
       "output_file_grp_cardinality": 1,


### PR DESCRIPTION
The `ocrd-pagetopdf` was only usable for me with some adjustments to the `ocrd.json` file. Error message:

```
<report valid="false">
  <error>[tools.ocrd-pagetopdf.steps.0] 'post-processing/format-conversion' is not one of ['preprocessing/format-conversion', 'preprocessing/characterization', 'preprocessing/optimization', 'preprocessing/optimization/cropping', 'preprocessing/optimization/deskewing', 'preprocessing/optimization/despeckling', 'preprocessing/optimization/dewarping', 'preprocessing/optimization/binarization', 'preprocessing/optimization/grayscale_normalization', 'recognition/text-recognition', 'recognition/font-identification', 'recognition/post-correction', 'layout/segmentation', 'layout/segmentation/text-nontext', 'layout/segmentation/region', 'layout/segmentation/line', 'layout/segmentation/word', 'layout/segmentation/classification', 'layout/analysis', 'postprocessing/format-conversion', 'postprocessing/archival', 'evaluation/layout', 'evaluation/text']</error>
  <error>[tools.ocrd-altotopdf.steps.0] 'post-processing/format-conversion' is not one of ['preprocessing/format-conversion', 'preprocessing/characterization', 'preprocessing/optimization', 'preprocessing/optimization/cropping', 'preprocessing/optimization/deskewing', 'preprocessing/optimization/despeckling', 'preprocessing/optimization/dewarping', 'preprocessing/optimization/binarization', 'preprocessing/optimization/grayscale_normalization', 'recognition/text-recognition', 'recognition/font-identification', 'recognition/post-correction', 'layout/segmentation', 'layout/segmentation/text-nontext', 'layout/segmentation/region', 'layout/segmentation/line', 'layout/segmentation/word', 'layout/segmentation/classification', 'layout/analysis', 'postprocessing/format-conversion', 'postprocessing/archival', 'evaluation/layout', 'evaluation/text']</error>
</report>.
```